### PR TITLE
Add Rust 1.60 as the MSRV to Cargo.toml

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,9 +13,15 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    matrix:
+      # The MSRV is Rust 1.60.
+      rust-toolchain: [1.60, stable]
 
     steps:
     - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@v1
+      with:
+        toolchain: ${{ matrix.rust-toolchain }}
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ repository = "https://github.com/cameron1024/unarray"
 license = "MIT OR Apache-2.0"
 version = "0.1.4"
 edition = "2021"
+rust-version = "1.60"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "Utilities for working with uninitialized arrays"
 repository = "https://github.com/cameron1024/unarray"
 license = "MIT OR Apache-2.0"
 version = "0.1.4"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Hi!

I have a library for which the MSRV is Rust 1.56 -- unarray, which is now used by proptest, got pulled in and the project failed to compile.

I've now checked in a Cargo.lock, but I thought it would be good to have Rust 1.60 be explicitly declared as the MSRV.